### PR TITLE
Alternative on the way to select loan provider

### DIFF
--- a/contracts/WidoCollateralSwap.sol
+++ b/contracts/WidoCollateralSwap.sol
@@ -64,19 +64,18 @@ contract WidoCollateralSwap is IERC3156FlashBorrower, IFlashLoanSimpleReceiver {
         POOL = IPool(_addressProvider.getPool());
     }
 
-    /// @notice Performs a collateral swap
+    /// @notice Performs a collateral swap with Equalizer
     /// @param existingCollateral The collateral currently locked in the Comet contract
     /// @param finalCollateral The final collateral desired collateral
     /// @param sigs The required signatures to allow and revoke permission to this contract
     /// @param swap The necessary data to swap one collateral for the other
     /// @param comet The address of the Comet contract to interact with
-    function swapCollateral(
+    function swapCollateralEqualizer(
         Collateral calldata existingCollateral,
         Collateral calldata finalCollateral,
         Signatures calldata sigs,
         WidoSwap calldata swap,
-        address comet,
-        Provider provider
+        address comet
     ) external {
         bytes memory data = abi.encode(
             msg.sender,
@@ -86,26 +85,42 @@ contract WidoCollateralSwap is IERC3156FlashBorrower, IFlashLoanSimpleReceiver {
             swap
         );
 
-        if (provider == Provider.Equalizer) {
-            equalizerProvider.flashLoan(
-                IERC3156FlashBorrower(this),
-                finalCollateral.addr,
-                finalCollateral.amount,
-                data
-            );
-        }
-        else if (provider == Provider.Aave) {
-            POOL.flashLoanSimple(
-                address(this),
-                finalCollateral.addr,
-                finalCollateral.amount,
-                data,
-                0
-            );
-        }
-        else {
-            revert InvalidProvider();
-        }
+        equalizerProvider.flashLoan(
+            IERC3156FlashBorrower(this),
+            finalCollateral.addr,
+            finalCollateral.amount,
+            data
+        );
+    }
+
+    /// @notice Performs a collateral swap with Aave
+    /// @param existingCollateral The collateral currently locked in the Comet contract
+    /// @param finalCollateral The final collateral desired collateral
+    /// @param sigs The required signatures to allow and revoke permission to this contract
+    /// @param swap The necessary data to swap one collateral for the other
+    /// @param comet The address of the Comet contract to interact with
+    function swapCollateralAave(
+        Collateral calldata existingCollateral,
+        Collateral calldata finalCollateral,
+        Signatures calldata sigs,
+        WidoSwap calldata swap,
+        address comet
+    ) external {
+        bytes memory data = abi.encode(
+            msg.sender,
+            comet,
+            existingCollateral,
+            sigs,
+            swap
+        );
+
+        POOL.flashLoanSimple(
+            address(this),
+            finalCollateral.addr,
+            finalCollateral.amount,
+            data,
+            0
+        );
     }
 
     /**


### PR DESCRIPTION
This method could save a little bit of gas by:
- Reducing the number of arguments to the function (- Provider)
- Reducing the IF on the on-chain logic

Would increase the gas when:
- The second function is called(top functions are cheapest to call, and a constant gas is added each function down). So the second function would be a bit more costly than the first. We should put on top the one we think it's gonna be called more often.

Since we have to make the distinction anyway on the SDK to pick provider, we can just decide the function to call instead of sending the argument.

What do you think @jainkunal ? Worth it?

(didnt compute how much saving we're talking)