### PR TITLE
Zap out estimation

### DIFF
--- a/contracts/core/zapper/WidoZapperUniswapV2.sol
+++ b/contracts/core/zapper/WidoZapperUniswapV2.sol
@@ -85,16 +85,18 @@ contract WidoZapperUniswapV2 is WidoZapper {
 
         if (isZapToToken0) {
             amount0 = (lpAmount * reserve0) / lpTotalSupply;
+            uint amt1Out = (lpAmount * reserve1) / lpTotalSupply;
             amount1 = _getAmountOut(
                 router,
-                (lpAmount * reserve1) / lpTotalSupply,
+                (lpAmount * (reserve1 - amt1Out)) / (lpTotalSupply - lpAmount),
                 asset1, asset0,
                 extra
             );
         } else {
+            uint amt0Out = (lpAmount * reserve0) / lpTotalSupply;
             amount0 = _getAmountOut(
                 router,
-                (lpAmount * reserve0) / lpTotalSupply,
+                (lpAmount * (reserve0 - amt0Out)) / (lpTotalSupply - lpAmount),
                 asset0, asset1,
                 extra
             );


### PR DESCRIPTION
Trying to improve the zapOut estimation. 

Since we want to estimate the output of the swap **after the withdraw**, the reserves and totalSupply we have are not the ones that will be used when swapping, hence the new operations.

There's still a problem, it is that the internal function `getAmountOut` that is called to get the output value, since it's being called before we actually withdraw anything, is still using the actual current values, so the estimation is potentially not accurate.

The only way I see to be precise is to copy the logic into our contracts so we can use the "by then real values".